### PR TITLE
Unify how version is extracted across languages

### DIFF
--- a/workflows/staging-automation/golang-projects.yml
+++ b/workflows/staging-automation/golang-projects.yml
@@ -37,7 +37,7 @@ jobs:
           script: |
             const { GITHUB_CONTEXT } = process.env
             const githubContext = JSON.parse(GITHUB_CONTEXT)
-            const newVersion = githubContext.head_ref.split('-')[1]
+            const newVersion = githubContext.head_ref.split('-v')[1]
             return newVersion
 
       - name: Build Changelog
@@ -57,7 +57,7 @@ jobs:
           script: |
             const fs = require("fs");
             const currentContent = fs.readFileSync('CHANGELOG.md', 'utf8');
-            const version = '${{ steps.extract_version.outputs.result}}'
+            const version = 'v${{ steps.extract_version.outputs.result}}'
             const changelog = ${{ toJson(steps.build_changelog.outputs.changelog) }}
             const newContent = [`# ${version}\n\n`,`${changelog}\n\n`,`${currentContent}`].join('');
             fs.writeFileSync('CHANGELOG.md',newContent);
@@ -74,7 +74,7 @@ jobs:
       - name: Commit Changelog and version increase
         uses: stefanzweifel/git-auto-commit-action@v4.14.1
         with:
-          commit_message: 'chore: release version ${{ steps.extract_version.outputs.result }} and update CHANGELOG.md'
+          commit_message: 'chore: release version v${{ steps.extract_version.outputs.result }} and update CHANGELOG.md'
           commit_options: '--no-verify'
           push_options: --force
           commit_user_name: Gigapipe Bot
@@ -180,7 +180,7 @@ jobs:
         with:
           # ⚙️ Put the slack channel id where you want the message to be sent here
           channel-id: CHANNEL_ID
-          slack-message: '🚀  *Launchpad v${{steps.extract_version.outputs.version}}* deployed to *STAGING*'
+          slack-message: '🚀  *Launchpad v${{ needs.prepare-build.outputs.newVersion }}* deployed to *STAGING*'
           payload: |
             {
               "blocks": [
@@ -188,7 +188,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Launchpad v${{steps.extract_version.outputs.version}} - Deployed to STAGING 🚀",
+                    "text": "Launchpad v${{ needs.prepare-build.outputs.newVersion }} - Deployed to STAGING 🚀",
                     "emoji": true
                   }
                 },

--- a/workflows/staging-automation/javascript-projects.yml
+++ b/workflows/staging-automation/javascript-projects.yml
@@ -36,7 +36,7 @@ jobs:
           script: |
             const { GITHUB_CONTEXT } = process.env
             const githubContext = JSON.parse(GITHUB_CONTEXT)
-            const newVersion = githubContext.head_ref.split('-')[1]
+            const newVersion = githubContext.head_ref.split('-v')[1]
             return newVersion
 
       - name: Build Changelog
@@ -56,7 +56,7 @@ jobs:
           script: |
             const fs = require("fs");
             const currentContent = fs.readFileSync('CHANGELOG.md', 'utf8');
-            const version = '${{ steps.extract_version.outputs.result}}'
+            const version = 'v${{ steps.extract_version.outputs.result}}'
             const changelog = ${{ toJson(steps.build_changelog.outputs.changelog) }}
             const newContent = [`# ${version}\n\n`,`${changelog}\n\n`,`${currentContent}`].join('');
             fs.writeFileSync('CHANGELOG.md',newContent);
@@ -67,7 +67,7 @@ jobs:
       - name: Commit Changelog and version increase
         uses: stefanzweifel/git-auto-commit-action@v4.14.1
         with:
-          commit_message: 'chore: release version ${{ steps.extract_version.outputs.result }} and update CHANGELOG.md'
+          commit_message: 'chore: release version v${{ steps.extract_version.outputs.result }} and update CHANGELOG.md'
           commit_options: '--no-verify'
           push_options: --force
           commit_user_name: Gigapipe Bot

--- a/workflows/staging-automation/python-projects.yml
+++ b/workflows/staging-automation/python-projects.yml
@@ -59,7 +59,7 @@ jobs:
           script: |
             const fs = require("fs");
             const currentContent = fs.readFileSync('CHANGELOG.md', 'utf8');
-            const version = '${{ steps.extract_version.outputs.result}}'
+            const version = 'v${{ steps.extract_version.outputs.result}}'
             const changelog = ${{ toJson(steps.build_changelog.outputs.changelog) }}
             const newContent = [`# ${version}\n\n`,`${changelog}\n\n`,`${currentContent}`].join('');
             fs.writeFileSync('CHANGELOG.md',newContent);
@@ -77,7 +77,7 @@ jobs:
       - name: Commit Changelog and version increase
         uses: stefanzweifel/git-auto-commit-action@v4.14.1
         with:
-          commit_message: 'chore: release version ${{ steps.extract_version.outputs.result }} and update CHANGELOG.md'
+          commit_message: 'chore: release version v${{ steps.extract_version.outputs.result }} and update CHANGELOG.md'
           commit_options: '--no-verify'
           push_options: --force
           commit_user_name: Gigapipe Bot


### PR DESCRIPTION
## Description

<!--- Put a single sentence summary of what are you achieving with this PR. Technical description of the task with more in-depth details than the ones available in the original ticket. -->

This PR makes sure the extracted version from the branch name or the committed file follows always the same pattern across languages. On each workflow, the version variable would be always the numeric value without the leading `v` that will be added when necessary on composing strings or other variables.

## Considerations

<!--- What technical details should the team pay particular attention to? What unexpected issues did you encounter? The how and why of the changes, are very useful for historical reference.  -->

## Tests

<!--- Why did you add tests around the areas you did? If none, explain why. (optional) -->
